### PR TITLE
Fix SpeakerPage pagination (#35)

### DIFF
--- a/NextTechEvent/NextTechEvent/NextTechEvent.Client/Pages/ConferenceItem.razor.css
+++ b/NextTechEvent/NextTechEvent/NextTechEvent.Client/Pages/ConferenceItem.razor.css
@@ -1,6 +1,7 @@
 ﻿.card
 {
     width:100%;
+    position: relative;
 }
 time {
     margin-left: 4px;

--- a/NextTechEvent/NextTechEvent/NextTechEvent.Client/Pages/ConferencePage.razor.css
+++ b/NextTechEvent/NextTechEvent/NextTechEvent.Client/Pages/ConferencePage.razor.css
@@ -2,6 +2,10 @@
     align-items:start !important;
 }
 
+.card {
+    position: relative;
+}
+
 .temperature {
     font-size: 2rem;
     font-weight: bold;

--- a/NextTechEvent/NextTechEvent/NextTechEvent.Client/Pages/SpeakerPage.razor
+++ b/NextTechEvent/NextTechEvent/NextTechEvent.Client/Pages/SpeakerPage.razor
@@ -28,9 +28,13 @@
         <text>No results</text>
     }
     
-    <button @onclick="PreviousPage">Previous</button>
-    <button @onclick="NextPage">Next</button>
 </div>
+
+<nav class="d-flex justify-content-center align-items-center gap-3 mt-3" aria-label="Conference list pagination">
+    <button @onclick="PreviousPage" disabled="@(currentpage == 0)" aria-label="Previous page">Previous</button>
+    <span aria-current="page">Page @(currentpage + 1)</span>
+    <button @onclick="NextPage" disabled="@(IsLastPage)" aria-label="Next page">Next</button>
+</nav>
 
 @code {
     [PersistentState]
@@ -86,6 +90,8 @@
 
     int pagesize = 10;
     int currentpage = 0;
+    bool IsLastPage => Conferences != null && Conferences.Count < pagesize;
+
     private async Task LoadDataAsync(bool reload)
     {
         if(reload)

--- a/NextTechEvent/NextTechEventNet7/Pages/ConferenceItem.razor.css
+++ b/NextTechEvent/NextTechEventNet7/Pages/ConferenceItem.razor.css
@@ -1,6 +1,7 @@
 ﻿.card
 {
     width:100%;
+    position: relative;
 }
 time {
     margin-left: 4px;

--- a/NextTechEvent/NextTechEventNet7/Pages/ConferencePage.razor.css
+++ b/NextTechEvent/NextTechEventNet7/Pages/ConferencePage.razor.css
@@ -2,6 +2,10 @@
     align-items:start !important;
 }
 
+.card {
+    position: relative;
+}
+
 .temperature {
     font-size: 2rem;
     font-weight: bold;

--- a/NextTechEvent/NextTechEventNet7/Pages/SpeakerPage.razor
+++ b/NextTechEvent/NextTechEventNet7/Pages/SpeakerPage.razor
@@ -19,10 +19,14 @@
     {
         <text>No results</text>
     }
-    
-    <button @onclick="PreviousPage">Previous</button>
-    <button @onclick="NextPage">Next</button>
+
 </div>
+
+<nav class="d-flex justify-content-center align-items-center gap-3 mt-3" aria-label="Conference list pagination">
+    <button @onclick="PreviousPage" disabled="@(currentpage == 0)" aria-label="Previous page">Previous</button>
+    <span aria-current="page">Page @(currentpage + 1)</span>
+    <button @onclick="NextPage" disabled="@(IsLastPage)" aria-label="Next page">Next</button>
+</nav>
 
 @code {
     List<Conference> Conferences = new();
@@ -77,6 +81,8 @@
 
     int pagesize = 10;
     int currentpage = 0;
+    bool IsLastPage => Conferences.Count < pagesize;
+
     private async Task LoadDataAsync()
     {
         Conferences = Enumerable.Repeat(new Conference(), pagesize).ToList();


### PR DESCRIPTION
Fixes #35. Moves Previous/Next pagination buttons out of the conference cards flex container into a semantic nav element. Adds disabled states for Previous (page 0) and Next (last page). Adds a Page N indicator with aria-current. Includes aria-labels for accessibility. Applied to both NextTechEvent.Client and NextTechEventNet7.